### PR TITLE
Pchip support added to final interpolation of lookup mode 3

### DIFF
--- a/src/pygmid/Lookup.py
+++ b/src/pygmid/Lookup.py
@@ -2,9 +2,18 @@ import copy
 
 import numpy as np
 import scipy.io
-from scipy.interpolate import interpn, interp1d
+from scipy.interpolate import interpn, interp1d, PchipInterpolator
 
 eps = np.finfo(float).eps
+
+def interp1(x, y, **ipkwargs):
+    METHOD = ipkwargs.pop('METHOD')
+    methods = {
+        'linear' : interp1d,
+        'pchip'  : PchipInterpolator
+    }
+    
+    return methods[METHOD](x,y, **ipkwargs)
 
 class Lookup:
     def __init__(self, filename="MOS.mat"):
@@ -230,7 +239,7 @@ class Lookup:
 
         dim = x.shape
         output = np.zeros((dim[1], len(xdesired)))
-        ipkwargs = {'fill_value' : np.nan, 'bounds_error': False}
+        ipkwargs = {'fill_value' : np.nan, 'bounds_error': False, 'METHOD' : pars['METHOD']}
         for i in range(0, dim[1]):
             for j in range(0, len(xdesired)):
                 m = max(x[:, i])
@@ -241,20 +250,23 @@ class Lookup:
                     x_right = x[idx:-1, i]
                     y_right = y[idx:-1, i]
                     # need to implement pchip interpolation here
-                    output[i, j] = interp1d(x_right, y_right, **ipkwargs)(xdesired[j])
+                    #output[i, j] = interp1d(x_right, y_right, **ipkwargs)(xdesired[j])
+                    output[i, j] = interp1(x_right, y_right, **ipkwargs)(xdesired[j])
                 elif (num.upper() == 'GM') and (den.upper() == 'CGG') or (den.upper() == 'CGG'):
                     x_left = x[1:idx, i]
                     y_left = y[1:idx, i]
                     # need to implement pchip interpolation here
-                    output[i, j] = interp1d(x_left, y_left, **ipkwargs)(xdesired[j])
+                    #output[i, j] = interp1d(x_right, y_right, **ipkwargs)(xdesired[j])
+                    output[i, j] = interp1(x_right, y_right, **ipkwargs)(xdesired[j])
                 else:
                     crossings = len(np.argwhere(np.diff(np.sign(x[:,i]-xdesired[j]+eps))))
                     if crossings > 1:
                         print('Crossing warning')
                         return []
                 # need to implement pchip interpolation here
-                output[i, j] = interp1d(x[:,i], y[:, i], **ipkwargs)(xdesired[j])
-        
+                #output[i, j] = interp1d(x_right, y_right, **ipkwargs)(xdesired[j])
+                output[i, j] = interp1(x_right, y_right, **ipkwargs)(xdesired[j])
+
         output = np.squeeze(output)
 
         return output

--- a/src/pygmid/constants.py
+++ b/src/pygmid/constants.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+eps = np.finfo(float).eps

--- a/src/pygmid/utility.py
+++ b/src/pygmid/utility.py
@@ -1,0 +1,27 @@
+import numpy as np
+from scipy.interpolate import interpn, interp1d, PchipInterpolator
+
+def ensure_monotonically_increasing(x):
+    return np.all(np.diff(x) > 0)
+
+def interp1(x, y, **ipkwargs):
+    """
+    Wrapper function for the 1d interpolation
+    at end of lookup mode 3.
+
+    Python does not support pchip as a 1d interpolation method.
+    Have to use a wrapper function to access both
+
+    Args:
+        filename
+    """
+
+    METHOD = ipkwargs.pop('METHOD')
+    if METHOD == 'pchip':
+        if not ensure_monotonically_increasing(x):
+            # reverse arrays for interpolator
+            return PchipInterpolator(x[::-1], y[::-1])
+        else:
+            return PchipInterpolator(x, y)
+    else:
+        return interp1d(x, y, **ipkwargs)

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -87,3 +87,5 @@ plt.ylabel(r"$g_m/g_{DS}$")
 plt.xlabel(r"$g_m/I_D$")
 plt.title(r'$g_m/g_{DS}$ vs. $g_m/I_D$')
 plt.show()
+
+# %%


### PR DESCRIPTION
see title.

User can also set default values of lookup object using kwargs at instanciation. Default interpolation method is pchip.