### PR TITLE
access properties of Lookup object with lower-case identifiers

### DIFF
--- a/src/pygmid/Lookup.py
+++ b/src/pygmid/Lookup.py
@@ -85,7 +85,7 @@ class Lookup:
         return None
 
     def __contains__(self, key):
-        return key in self.__DATA.keys()
+        return key.upper() in self.__DATA.keys()
 
     def __getitem__(self, key):
         """
@@ -96,7 +96,7 @@ class Lookup:
         if key not in self:
             raise ValueError(f"Lookup table does not contain this data")
 
-        return np.copy(self.__DATA[key])
+        return np.copy(self.__DATA[key.upper()])
 
     def _modeset(self, outkey, varkey):
         """


### PR DESCRIPTION
The user can provide keyword arguments to the `look_up` method in lower and upper-case syntax, e.g.

`NCH.look_up('GMB', vds=10, vgs=0.6, vsb=0.0, l=1)`

and 

`NCH.look_up('GMB', VDS=10, VGS=0.6, VSB=0.0, L=1)`

are equivalent.
The same mechanism does not work when properties of the lookup object are accessed, i.e.,

`NCH['VGS']`

works, but

`NCH['vgs']`

does not work.


