### PR TITLE
add print representation of Lookup object

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,12 +24,14 @@ setup_requires =
     matplotlib
     psf_utils
     tqdm
+    prettytable
 install_requires = 
     numpy
     scipy
     matplotlib
     psf_utils
     tqdm
+    prettytable
     
 [options.packages.find]
 where = src

--- a/src/pygmid/Lookup.py
+++ b/src/pygmid/Lookup.py
@@ -4,6 +4,7 @@ import numpy as np
 import scipy.io
 from scipy.interpolate import interpn
 import pickle
+import prettytable
 
 from .constants import *
 from .numerical import interp1
@@ -413,3 +414,23 @@ class Lookup:
                     dimensions
         """
         return self.look_up('SFL_STH', **kwargs)
+
+    def __str__(self):
+
+        tab = prettytable.PrettyTable()
+        tab.field_names = ['Variable', 'Size', 'Min', 'Max']
+
+        for k, v in self.__DATA.items():
+
+            is_numeric = np.issubdtype(v.dtype, np.number)
+
+            if is_numeric:
+              size = str(v.shape).replace('(', '').replace(')', '').\
+                                  replace(', ', 'x').replace(',', '')
+
+            tab.add_row([ k
+                        , size             if size       else '1'
+                        , f'{v.min():.2e}' if is_numeric else 'N/A'
+                        , f'{v.max():.2e}' if is_numeric else 'N/A'])
+
+        return tab.get_string()


### PR DESCRIPTION
Printing a Lookup object (`print(NCH)`) will show a reasonable print representation:

```
+----------+-------------+-----------+----------+
| Variable |     Size    |    Min    |   Max    |
+----------+-------------+-----------+----------+
|    ID    | 32x73x73x11 | -0.00e+00 | 3.19e-03 |
|    VT    | 32x73x73x11 |  3.79e-01 | 7.20e-01 |
|    GM    | 32x73x73x11 |  0.00e+00 | 2.92e-03 |
|   GMB    | 32x73x73x11 |  0.00e+00 | 7.32e-04 |
|   GDS    | 32x73x73x11 |  4.72e-16 | 1.08e-02 |
|   CGG    | 32x73x73x11 |  6.08e-15 | 8.80e-14 |
|   CGS    | 32x73x73x11 |  2.45e-15 | 7.09e-14 |
|   CGD    | 32x73x73x11 |  2.26e-15 | 4.25e-14 |
|   CGB    | 32x73x73x11 | -2.40e-16 | 2.41e-14 |
|   CDD    | 32x73x73x11 |  5.39e-15 | 1.20e-13 |
|   CSS    | 32x73x73x11 |  6.03e-15 | 8.02e-14 |
|   STH    | 32x73x73x11 |  9.96e-34 | 1.79e-22 |
|   SFL    | 32x73x73x11 |  0.00e+00 | 4.82e-15 |
|   INFO   | 32x73x73x11 |    N/A    |   N/A    |
|  CORNER  | 32x73x73x11 |    N/A    |   N/A    |
|   TEMP   |      1      |  3.00e+02 | 3.00e+02 |
|   VGS    |      73     |  0.00e+00 | 1.80e+00 |
|   VDS    |      73     |  0.00e+00 | 1.80e+00 |
|   VSB    |      11     |  0.00e+00 | 1.00e+00 |
|    L     |      32     |  1.80e-01 | 2.00e+00 |
|    W     |      1      |  5.00e+00 | 5.00e+00 |
|  NFING   |      1      |  1.00e+00 | 1.00e+00 |
+----------+-------------+-----------+----------+
```
